### PR TITLE
Changing functionality to pass in a username at runtime

### DIFF
--- a/Week-4-GitHub-And-SourceControl/iamuser.py
+++ b/Week-4-GitHub-And-SourceControl/iamuser.py
@@ -31,6 +31,6 @@ def new_iam_user(username):
             'Users access key was not created. Please confirm you have permissions to utilize programmatic access in AWS and try again')
 
 username = sys.argv[1]
-
+# Checking SomaDevops
 if __name__ == '__main__':
     new_iam_user(username)


### PR DESCRIPTION
This feature allows users to pass in a username at runtime. It makes the code reusable and anyone can use it in their environment.